### PR TITLE
Add per-page markdown `env` setting feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,22 @@ md.parser.enable(['embpahsis', 'html_block', 'html_tag']);
 metalsmith.use(md);
 ```
 
+The parser's `enable`, `disable`, `use` and `set` methods are proxied on the metalsmith plugin, so you may access them like so:
+
+```js
+var markdown = require('metalsmith-multimarkdownit');
+
+metalsmith.use(markdown('zero', {html: true}).enable('emphasis', 'html_block', 'html_tag'))
+```
+
+You may provide a function to set the parser & renderer's environment on a per-page basis, should you need to:
+
+```js
+var markdown = require('metalsmith-multimarkdownit');
+
+metalsmith.use(markdown('default').env(function(page){ return page; }))
+```
+
 ## License
 
   MIT

--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,7 @@ metalsmith.use(md);
 The parser's `enable`, `disable`, `use` and `set` methods are proxied on the metalsmith plugin, so you may access them like so:
 
 ```js
-var markdown = require('metalsmith-multimarkdownit');
+var markdown = require('metalsmith-markdownit');
 
 metalsmith.use(markdown('zero', {html: true}).enable('emphasis', 'html_block', 'html_tag'))
 ```
@@ -71,7 +71,7 @@ metalsmith.use(markdown('zero', {html: true}).enable('emphasis', 'html_block', '
 You may provide a function to set the parser & renderer's environment on a per-page basis, should you need to:
 
 ```js
-var markdown = require('metalsmith-multimarkdownit');
+var markdown = require('metalsmith-markdownit');
 
 metalsmith.use(markdown('default').env(function(page){ return page; }))
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,8 @@ module.exports = plugin;
  */
 
 function plugin(preset, options){
-  var markdown = new markdownIt(preset, options);
-
+  var markdown = new markdownIt(preset, options),
+      envSetter = function(){};
 
   var plugin = function(files, metalsmith, done){
     setImmediate(done);
@@ -33,7 +33,7 @@ function plugin(preset, options){
       if ('.' != dir) html = dir + '/' + html;
 
       debug('converting file: %s', file);
-      var str = markdown.render(data.contents.toString());
+      var str = markdown.render(data.contents.toString(), envSetter(data));
       data.contents = new Buffer(str);
 
       delete files[file];
@@ -52,6 +52,11 @@ function plugin(preset, options){
       return plugin;
     }
   });
+
+  plugin.env = function(setter){
+    envSetter = setter;
+    return plugin;
+  }
 
   plugin.withParser = function(fn){
     fn(markdown);

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,11 @@ function plugin(preset, options){
       if ('.' != dir) html = dir + '/' + html;
 
       debug('converting file: %s', file);
-      var str = markdown.render(data.contents.toString(), envSetter(data));
+      var env = {};
+      if (envSetter) {
+        env = envSetter(data, metalsmith.metadata());
+      }
+      var str = markdown.render(data.contents.toString(), env);
       data.contents = new Buffer(str);
 
       delete files[file];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metalsmith-markdownit",
   "description": "A Metalsmith plugin to convert markdown files.",
   "repository": "git://github.com/mayo/metalsmith-markdownit.git",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/test/fixtures/env-plugin/expected/index.html
+++ b/test/fixtures/env-plugin/expected/index.html
@@ -1,1 +1,1 @@
-<p>Shall we render the This is my page title now?</p>
+<p>Shall we render the This is my page title now? Btw, we're on The test build site.</p>

--- a/test/fixtures/env-plugin/expected/index.html
+++ b/test/fixtures/env-plugin/expected/index.html
@@ -1,0 +1,1 @@
+<p>Shall we render the This is my page title now?</p>

--- a/test/fixtures/env-plugin/src/index.md
+++ b/test/fixtures/env-plugin/src/index.md
@@ -2,4 +2,4 @@
 title: This is my page title
 ---
 
-Shall we render the @title now?
+Shall we render the @title now? Btw, we're on @siteName site.

--- a/test/fixtures/env-plugin/src/index.md
+++ b/test/fixtures/env-plugin/src/index.md
@@ -1,0 +1,5 @@
+---
+title: This is my page title
+---
+
+Shall we render the @title now?

--- a/test/index.js
+++ b/test/index.js
@@ -92,29 +92,32 @@ describe('metalsmith-markdown', function(){
 
   it('should be able to set the rendering environment per-page', function(done){
     Metalsmith('test/fixtures/env-plugin')
-      .use(markdown('default').env(function(page){ return page; }).use(function(md){
-        md.inline.ruler.push('vars', function(state, silent){
-          var pos = state.pos,
-              max = state.posMax;
-          if (state.src.charCodeAt(pos) !== '@'.charCodeAt(0)) { return false; }
-          while (pos < max) {
-            pos++;
-            if (state.md.utils.isSpace(state.src.charCodeAt(pos))){break;}
-          }
-          if (!silent) {
-            var name = state.src.slice(state.pos + 1, pos),
-                token = state.push('vars', '', 0);
-            token.markup = "@" + name;
-            token.content = state.env[name];
-          }
-          state.pos = pos;
-          return true;
-        });
-        md.renderer.rules['vars'] = function(tokens, id, options, env, self){
-          var token = tokens[id];
-          return token.content;
-        }
-      }))
+      .metadata({siteName: 'The test build'})
+      .use(markdown('default')
+           .env(function(page, metadata){ return {title: page.title, siteName: metadata.siteName}; })
+           .use(function(md){
+             md.inline.ruler.push('vars', function(state, silent){
+               var pos = state.pos,
+                   max = state.posMax;
+               if (state.src.charCodeAt(pos) !== '@'.charCodeAt(0)) { return false; }
+               while (pos < max) {
+                 pos++;
+                 if (state.md.utils.isSpace(state.src.charCodeAt(pos))){break;}
+               }
+               if (!silent) {
+                 var name = state.src.slice(state.pos + 1, pos),
+                     token = state.push('vars', '', 0);
+                 token.markup = "@" + name;
+                 token.content = state.env[name];
+               }
+               state.pos = pos;
+               return true;
+             });
+             md.renderer.rules['vars'] = function(tokens, id, options, env, self){
+               var token = tokens[id];
+               return token.content;
+             }
+           }))
       .build(function(err){
         if (err) return done(err);
         equal('test/fixtures/env-plugin/expected', 'test/fixtures/env-plugin/build');

--- a/test/index.js
+++ b/test/index.js
@@ -89,4 +89,36 @@ describe('metalsmith-markdown', function(){
         done();
       });
   });
+
+  it('should be able to set the rendering environment per-page', function(done){
+    Metalsmith('test/fixtures/env-plugin')
+      .use(markdown('default').env(function(page){ return page; }).use(function(md){
+        md.inline.ruler.push('vars', function(state, silent){
+          var pos = state.pos,
+              max = state.posMax;
+          if (state.src.charCodeAt(pos) !== '@'.charCodeAt(0)) { return false; }
+          while (pos < max) {
+            pos++;
+            if (state.md.utils.isSpace(state.src.charCodeAt(pos))){break;}
+          }
+          if (!silent) {
+            var name = state.src.slice(state.pos + 1, pos),
+                token = state.push('vars', '', 0);
+            token.markup = "@" + name;
+            token.content = state.env[name];
+          }
+          state.pos = pos;
+          return true;
+        });
+        md.renderer.rules['vars'] = function(tokens, id, options, env, self){
+          var token = tokens[id];
+          return token.content;
+        }
+      }))
+      .build(function(err){
+        if (err) return done(err);
+        equal('test/fixtures/env-plugin/expected', 'test/fixtures/env-plugin/build');
+        done();
+      })
+  })
 });


### PR DESCRIPTION
This hooks into a feature available to markdown-it plugins, and I have a custom plugin for which this would be very useful.
