### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "debug": "~0.7.4",
-    "markdown-it": "^5.0.0"
+    "debug": "~2.2.0",
+    "markdown-it": "^7.0.0"
   },
   "devDependencies": {
-    "mocha": "1.x",
-    "metalsmith": "0.x",
-    "assert-dir-equal": "0.x",
+    "mocha": "2.x",
+    "metalsmith": "2.x",
+    "assert-dir-equal": "1.x",
     "markdown-it-abbr": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
There has been two major version bumps on [markdown-it](https://github.com/markdown-it/markdown-it), so update may be in place.

Ran all the tests and updated `package.json`.
