### PR TITLE
Enable plugin options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 test/fixtures/*/build/*
+.DS_Store

--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,23 @@ metalsmith.use(markdown('default', {
 }));
 ```
 
+If you want to control plugin behaviour, you can set options under the `plugin` key of the `options` object (these options are not passed to Markdown It):
+
+```js
+metalsmith.use(markdown('default', {
+  typographer: true,
+  html: true,
+  plugin: {
+    // options.plugin.pattern (string) - glob pattern. Defaults to '**/*@(md|markdown)'
+    pattern: '**/*.html',  
+    // options.plugin.fields (string|Array) - field or list of fields to parse with Markdown-It. Defaults to 'contents'
+    fields: ['contents', 'excerpt']  
+    // options.plugin.extension (string) - the file extension for parsed files. Defaults to 'html'
+    extension: 'htm'
+  }
+}));
+```
+
 If you need access to markdown-it directly to enable features or use plugins, you can access the parser directly:
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,8 @@ function plugin(preset, options){
 
       debug('converting file: %s', file);
       pluginOptions.fields.forEach(function(field){
+        debug('- checking field: %s', field);
+        if (!data[field]) return
         debug('- converting field: %s', field);
         var str = markdown.render(data[field].toString(), env);
         data[field] = new Buffer(str);

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var dirname = require('path').dirname;
 var extname = require('path').extname;
 var join = require('path').join;
 var markdownIt = require('markdown-it');
+var minimatch = require('minimatch');
 
 /**
  * Expose `plugin`.
@@ -15,31 +16,63 @@ module.exports = plugin;
 /**
  * Metalsmith plugin to convert markdown files.
  *
- * @param {Object} options (optional)
+ * @param {Object}       options (optional) - options to pass to markdownIt
+ * @param {Object}       options.plugin (optional) - options used by the plugin. Will not be passed to MarkdownIt
+ * @param {string}       options.plugin.pattern - glob pattern for filtering which files to process (passed to minimatch.filter)
+ * @param {string|Array} options.plugin.fields - field or list of fields which MarkdownIt should process
+ * @param {string}       options.plugin.extension - file extension for output files
  * @return {Function}
  */
 
 function plugin(preset, options){
+  var defaults = {
+    pattern: '**/*.@(md|markdown)',
+    fields: 'contents',
+    extension: 'html'
+  }
+  var pluginOptions = defaults;
+
+  // handle cases where a preset isn't specified
+  var pluginOpts = false;
+  if (options && options.plugin) {
+    pluginOpts = options.plugin;
+    delete options.plugin;
+  } else if (!options && typeof preset === 'object' && preset.plugin){
+    pluginOpts = preset.plugin;
+    delete preset.plugin;
+  }
+
+  if (pluginOpts) {
+    // merge defaults with supplied options
+    for (var prop in pluginOpts) { 
+      pluginOptions[prop] = pluginOpts[prop];
+    }
+  }
+  // normalize pluginOptions.fields into an array
+  if (typeof pluginOptions.fields === 'string') pluginOptions.fields = [pluginOptions.fields]
+
   var markdown = new markdownIt(preset, options),
       envSetter = function(){};
 
   var plugin = function(files, metalsmith, done){
     setImmediate(done);
-    Object.keys(files).forEach(function(file){
-      debug('checking file: %s', file);
-      if (!is_markdown(file)) return;
+    Object.keys(files).filter(minimatch.filter(pluginOptions.pattern)).forEach(function(file){
       var data = files[file];
       var dir = dirname(file);
-      var html = basename(file, extname(file)) + '.html';
-      if ('.' != dir) html = join(dir, html);
+      var html = basename(file, extname(file)) + '.' + pluginOptions.extension;
+      if (dir !== '.') html = join(dir, html);
 
-      debug('converting file: %s', file);
       var env = {};
       if (envSetter) {
         env = envSetter(data, metalsmith.metadata());
       }
-      var str = markdown.render(data.contents.toString(), env);
-      data.contents = new Buffer(str);
+
+      debug('converting file: %s', file);
+      pluginOptions.fields.forEach(function(field){
+        debug('- converting field: %s', field);
+        var str = markdown.render(data[field].toString(), env);
+        data[field] = new Buffer(str);
+      })
 
       delete files[file];
       files[html] = data;
@@ -69,15 +102,4 @@ function plugin(preset, options){
   }
 
   return plugin;
-}
-
-/**
- * Check if a `file` is markdown.
- *
- * @param {String} file
- * @return {Boolean}
- */
-
-function is_markdown(file){
-  return /\.md|\.markdown/.test(extname(file));
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "debug": "~2.2.0",
-    "markdown-it": "^7.0.0"
+    "markdown-it": "^7.0.0",
+    "minimatch": "^3.0.3"
   },
   "devDependencies": {
     "mocha": "2.x",

--- a/test/fixtures/plugin-options-preset/expected/index.htm
+++ b/test/fixtures/plugin-options-preset/expected/index.htm
@@ -1,0 +1,4 @@
+<h1>A Markdown Post</h1>
+<p>With some &quot;amazing&quot;, <em>riveting</em>, <strong>coooonnnntent</strong>.</p>
+
+<p>The excerpt has <strong>bold</strong> text in it!</p>

--- a/test/fixtures/plugin-options-preset/src/index.html
+++ b/test/fixtures/plugin-options-preset/src/index.html
@@ -1,0 +1,7 @@
+---
+title: Test
+excerpt: The excerpt has **bold** text in it!
+---
+# A Markdown Post
+
+With some "amazing", _riveting_, **coooonnnntent**.

--- a/test/fixtures/plugin-options/expected/index.htm
+++ b/test/fixtures/plugin-options/expected/index.htm
@@ -1,0 +1,4 @@
+<h1>A Markdown Post</h1>
+<p>With some &quot;amazing&quot;, <em>riveting</em>, <strong>coooonnnntent</strong>.</p>
+
+<p>The excerpt has <strong>bold</strong> text in it!</p>

--- a/test/fixtures/plugin-options/src/index.html
+++ b/test/fixtures/plugin-options/src/index.html
@@ -1,0 +1,7 @@
+---
+title: Test
+excerpt: The excerpt has **bold** text in it!
+---
+# A Markdown Post
+
+With some "amazing", _riveting_, **coooonnnntent**.

--- a/test/index.js
+++ b/test/index.js
@@ -124,4 +124,49 @@ describe('metalsmith-markdown', function(){
         done();
       })
   })
+
+  it('should accept plugin options', function(done){
+    Metalsmith('test/fixtures/plugin-options')
+      .use(markdown({
+        plugin: {
+          pattern: '**/*.html',
+          fields: ['contents', 'excerpt'],
+          extension: 'htm'
+        }
+      }))
+      .use(function(files, metalsmith, done){
+        var f = files['index.htm'];
+        // concat the excerpt into the main content
+        f.contents = f.contents.toString() + '\n' + f.excerpt.toString()
+        done()
+      })
+      .build(function(err){
+        if (err) return done(err);
+        equal('test/fixtures/plugin-options/expected', 'test/fixtures/plugin-options/build');
+        done();
+      });
+  });
+
+  it('should accept plugin options with a preset', function(done){
+    Metalsmith('test/fixtures/plugin-options-preset')
+      .use(markdown('default', {
+        plugin: {
+          pattern: '**/*.html',
+          fields: ['contents', 'excerpt'],
+          extension: 'htm'
+        }
+      }))
+      .use(function(files, metalsmith, done){
+        var f = files['index.htm'];
+        // concat the excerpt into the main content
+        f.contents = f.contents.toString() + '\n' + f.excerpt.toString()
+        done()
+      })
+      .build(function(err){
+        if (err) return done(err);
+        equal('test/fixtures/plugin-options-preset/expected', 'test/fixtures/plugin-options/build');
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
Plugin can accept options under the `options.plugin` key.

For my use case, I often have markdown in multiple fields (e.g. excerpts) and my files don’t always have a .md file extension.

Default behaviour should be identical to the previous version.
