### PR TITLE
Use markdown-it 8.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metalsmith-markdownit",
   "description": "A Metalsmith plugin to convert markdown files.",
   "repository": "git://github.com/mayo/metalsmith-markdownit.git",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "debug": "~2.2.0",
-    "markdown-it": "^7.0.0",
+    "markdown-it": "^8.0.0",
     "minimatch": "^3.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi @mayo,

`markdown-it` has moved to version 8 but this project locks to 7.x release. You up for upgrading?